### PR TITLE
Fix menu bar color changing logic

### DIFF
--- a/LCMenuIconView.m
+++ b/LCMenuIconView.m
@@ -32,7 +32,6 @@
     highlightActiveImage = [[NSImage imageNamed:@"highlightactive"] retain];
     
 	NSImage *i = isActive ? activeImage : inactiveImage;
-	if(menuIsShown) i = isActive ? highlightActiveImage : highlightImage;
 	NSRect f = [self bounds];
 	NSPoint p = NSMakePoint(f.size.width/2 - [i size].width/2, f.size.height/2 - [i size].height/2 + 1);
 	

--- a/LCMenuIconView.m
+++ b/LCMenuIconView.m
@@ -22,8 +22,8 @@
     inactiveImage = [[NSImage imageNamed:@"inactive"] retain];
     
     // Invert icons if in dark mode
-    NSString *mode = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
-    if([mode isEqualToString: @"Dark"]) {
+    NSString *mode = (NSString*)(self.effectiveAppearance.name);
+    if([[mode lowercaseString] containsString: @"dark"]) {
         activeImage = [[NSImage imageNamed:@"highlightactive"] retain];
         inactiveImage = [[NSImage imageNamed:@"highlighted"] retain];
     }


### PR DESCRIPTION
The old logic for determining whether to display in dark mode or not doesn't work any more as the color of the menu bar isn't connected to whether the system is in dark mode or not.

Additionally, it's not the style any more to highlight menu bar icons when clicked on. Doing so makes them hard to see.